### PR TITLE
Fixed an issue when the zip path contains spaces.

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -50,7 +50,7 @@ zip=zip
 sevenzip=7z
 zip() {
 	archive="$1"; shift
-	$sevenzip a -tzip $archive "$@"
+	$sevenzip a -tzip "$archive" "$@"
 }
 
 unix2dos() {


### PR DESCRIPTION
release.sh tripped over my installing path (/f/Jeux/World of Warcraft) so I fixed the zip function.
