### PR TITLE
Fixes for SVN and some minor tweaks

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -72,45 +72,7 @@ skip_externals=
 skip_localization=
 skip_zipfile=
 
-# Set $topdir to top-level directory of the checkout.
-if [ -z "$topdir" ]; then
-	dir=$( $pwd )
-	if [ -d "$dir/.git" -o -d "$dir/.svn" ]; then
-		topdir=.
-	else
-		dir=${dir%/*}
-		topdir=..
-		while [ -n "$dir" ]; do
-			if [ -d "$topdir/.git" -o -d "$topdir/.svn" ]; then
-				break
-			fi
-			dir=${dir%/*}
-			topdir="$topdir/.."
-		done
-		if [ ! -d "$topdir/.git" -a ! -d "$topdir/.svn" ]; then
-			echo "No Git or SVN checkout found." >&2
-			exit 10
-		fi
-	fi
-fi
-
-# Set $releasedir to the directory which will contain the generated addon zipfile.
-: ${releasedir:="$topdir/release"}
-
-# Set $basedir to the basename of the checkout directory.
-basedir=$( cd "$topdir" && $pwd )
-case $basedir in
-/*/*)
-	basedir=${basedir##/*/}
-	;;
-/*)
-	basedir=${basedir##/}
-	;;
-esac
-
-# The default slug is the lowercase basename of the checkout directory.
-slug_default=$( echo "$basedir" | $tr '[A-Z]' '[a-z]' )
-
+# Process command-line options
 usage() {
 	echo "Usage: release.sh [-celouz] [-n name] [-p slug] [-r releasedir] [-t topdir]" >&2
 	echo "  -c               Skip copying files into the package directory." >&2
@@ -126,7 +88,6 @@ usage() {
 	echo "  -z               Skip zipfile creation." >&2
 }
 
-# Process command-line options
 OPTIND=1
 while $getopts ":celn:op:r:st:uz" opt; do
 	case $opt in
@@ -185,6 +146,45 @@ while $getopts ":celn:op:r:st:uz" opt; do
 	esac
 done
 shift $((OPTIND - 1))
+
+# Set $topdir to top-level directory of the checkout.
+if [ -z "$topdir" ]; then
+	dir=$( $pwd )
+	if [ -d "$dir/.git" -o -d "$dir/.svn" ]; then
+		topdir=.
+	else
+		dir=${dir%/*}
+		topdir=..
+		while [ -n "$dir" ]; do
+			if [ -d "$topdir/.git" -o -d "$topdir/.svn" ]; then
+				break
+			fi
+			dir=${dir%/*}
+			topdir="$topdir/.."
+		done
+		if [ ! -d "$topdir/.git" -a ! -d "$topdir/.svn" ]; then
+			echo "No Git or SVN checkout found." >&2
+			exit 10
+		fi
+	fi
+fi
+
+# Set $releasedir to the directory which will contain the generated addon zipfile.
+: ${releasedir:="$topdir/release"}
+
+# Set $basedir to the basename of the checkout directory.
+basedir=$( cd "$topdir" && $pwd )
+case $basedir in
+/*/*)
+	basedir=${basedir##/*/}
+	;;
+/*)
+	basedir=${basedir##/}
+	;;
+esac
+
+# The default slug is the lowercase basename of the checkout directory.
+slug_default=$( echo "$basedir" | $tr '[A-Z]' '[a-z]' )
 
 # Set $repository_type to "git" or "svn".
 repository_type=

--- a/release.sh
+++ b/release.sh
@@ -1225,7 +1225,7 @@ EOF
 			;;
 		svn)
 			# The SVN changelog is plain text.
-			$svn log -v $svn_revision_range
+			$svn log $topdir -v $svn_revision_range
 			;;
 		esac
 	) | line_ending_filter > "$pkgdir/$changelog"

--- a/release.sh
+++ b/release.sh
@@ -1222,7 +1222,7 @@ EOF
 		case $repository_type in
 		git)
 			# The Git changelog is Markdown-friendly.
-			$git log $git_commit_range --pretty=format:"###   %B" |
+			$git --git-dir $topdir/.git log $git_commit_range --pretty=format:"###   %B" |
 				$sed -e "s/^/    /g" -e "s/^ *$//g" -e "s/^    ###/-/g"
 			;;
 		svn)

--- a/release.sh
+++ b/release.sh
@@ -80,10 +80,10 @@ usage() {
 	echo "  -l               Skip @localization@ keyword replacement." >&2
 	echo "  -n name          Set the name of the addon." >&2
 	echo "  -o               Keep existing package directory; just overwrite contents." >&2
-	echo "  -p slug          Set the project slug used on WowAce or CurseForge. Defaults to \`\`$slug_default''." >&2
+	echo "  -p slug          Set the project slug used on WowAce or CurseForge." >&2
 	echo "  -r releasedir    Set directory containing the package directory. Defaults to \`\`\$topdir/release''." >&2
 	echo "  -s               Create a stripped-down \`\`nolib'' package." >&2
-	echo "  -t topdir        Set top-level directory of checkout.  Defaults to \`\`$topdir''." >&2
+	echo "  -t topdir        Set top-level directory of checkout." >&2
 	echo "  -u               Use Unix line-endings." >&2
 	echo "  -z               Skip zipfile creation." >&2
 }
@@ -139,7 +139,9 @@ while $getopts ":celn:op:r:st:uz" opt; do
 		exit 1
 		;;
 	\?)
-		echo "Unknown option \`\`-$OPTARG''." >&2
+		if [ "$OPTARG" != "?" ]; then
+			echo "Unknown option \`\`-$OPTARG''." >&2
+		fi
 		usage
 		exit 2
 		;;

--- a/release.sh
+++ b/release.sh
@@ -87,7 +87,7 @@ if [ -z "$topdir" ]; then
 			dir=${dir%/*}
 			topdir="$topdir/.."
 		done
-		if [ ! -d "$topdir/.git" -o -d "$topdir/.svn" ]; then
+		if [ ! -d "$topdir/.git" -a ! -d "$topdir/.svn" ]; then
 			echo "No Git or SVN checkout found." >&2
 			exit 10
 		fi


### PR DESCRIPTION
Was looking at moving some stuff to a custom build server and this script was perfect.

Most of the projects are SVN so I immediately noticed that the script was broken with them :(
1. SVN checkouts would always fail ([oops](https://github.com/ultijlam/curseforge-packager/blob/1b60c60612d4f35b6a55027396a20b4a97f0ab8e/release.sh#L90))
2. You couldn't actually set $topdir from the command-line because if the script was in a directory outside the checkout, it would fail before checking the options.
3. Changelogs wouldn't work if the script was in a directory that wasn't part of the checkout (mostly a SVN issue with uncommited/ignored directories, but you'd run into the same issue with both SVN and Git if you were outside of the checkout dir).
4. Nit picked the usage prints, don't complain about -? and topdir and slug would always show the default as "" unless you edited the script, at which point warranty is void :stuck_out_tongue_winking_eye:
